### PR TITLE
Updated to correct Docker container in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ version: "3"
 services:
     amcrest2mqtt:
         container_name: amcrest2mqtt
-        image: dchesterton/amcrest2mqtt:latest
+        image: myeager1967/amcrest2mqtt:latest
         restart: unless-stopped
         environment:
             AMCREST_HOST: 192.168.0.1


### PR DESCRIPTION
The Docker compose example in the README.md still referenced the dchesterton container. I updated it to pull yours.